### PR TITLE
map: Only unwrap plain objects returned from the mapper function.

### DIFF
--- a/lib/chance-generators.js
+++ b/lib/chance-generators.js
@@ -20,7 +20,7 @@
   function unwrap (v) {
     if (Array.isArray(v)) {
       return v.map(unwrap)
-    } else if (v && typeof v === 'object') {
+    } else if (v && typeof v === 'object' && v.constructor === Object) {
       return Object.keys(v).reduce(function (result, key) {
         result[key] = unwrap(v[key])
         return result

--- a/test/chance-generators.spec.js
+++ b/test/chance-generators.spec.js
@@ -327,6 +327,18 @@ describe('chance-generators', function () {
         )
       })
 
+      it('should not unwrap Object subclasses', () => {
+        function Foo (value) {
+          this.value = value
+        }
+
+        expect(
+          chance.integer({min: 0, max: 10}).map(value => new Foo(value)),
+          'when called',
+          'to be a', Foo
+        )
+      })
+
       describe('shrink', () => {
         it('returns a new generator where the input is shrunken with with regards to the original generator', () => {
           var generator = chance.shape({


### PR DESCRIPTION
Ran into this when I tried to return a `Buffer` instance from the mapper function. It got mangled to an `Object` instance with numerical properties.
