### PR TITLE
Fix bug in shrinking a mapped generator

### DIFF
--- a/lib/chance-generators.js
+++ b/lib/chance-generators.js
@@ -86,7 +86,7 @@
             if (value === lastMappedValue) {
               return generator.shrink(lastValue).map(f)
             } else {
-              return generator
+              return mapGenerator
             }
           }
         }

--- a/test/chance-generators.spec.js
+++ b/test/chance-generators.spec.js
@@ -75,6 +75,14 @@ describe('chance-generators', () => {
           }
           expect(generator, 'when called', 'to equal', 10)
         })
+
+        it('keeps the map even when called out of order', () => {
+          let generator = chance.integer({ min: -10, max: 10 }).map(v => '' + v)
+          const val = generator()
+          generator()
+          generator = generator.shrink(val)
+          expect(generator, 'when called', 'to be a string')
+        })
       })
     })
   })


### PR DESCRIPTION
I was running asynchronous tests with mapped generators, such that the tests were being resolved out of order, which meant that when one failed, a value was being supplied to the generator's shrink function that was not the last value produced. The problem with that was that the shrink function was returning the unmapped generator instead of the mapped one, which obviously breaks subsequent tests. Here's a fix.