### PR TITLE
[WIP] Make the generators stateless by providing the context to expand and shrink

### DIFF
--- a/documentation/api/iterator.md
+++ b/documentation/api/iterator.md
@@ -18,26 +18,6 @@ Is true if the iterator can be expanded.
 
 Is true if the iterator can be shrunken.
 
-### expand(value)
-
-Expands the current generator around the given value while still honoring the
-constraints of the original generator. The given value should be the last value
-the generator has produced.
-
-You can use this method when a generator produces an interesting input and you
-want to search around that value.
-
-```js
-const iterator = integer({ min: -10000, max: 10000 }).values();
-
-iterator.expand(100);
-
-expect(iterator.take(10), "to equal", [100, 9015, 100, 5594, 119, 100, 31, 100, 100, 174]);
-```
-
-As you can see the expanded iterator will produce values around `100` as that is
-our expansion value.
-
 ### next()
 
 Produces a new value based on the [generator](../generator/) that this iterator
@@ -46,48 +26,95 @@ was created from.
 ```js
 const integerIterator = integer.values();
 
-expect([integerIterator.next(), integerIterator.next(), integerIterator.next()], "to equal", [
-  -2260084377780223,
-  5342043492581377,
-  8119347222413313
-]);
+expect(
+  [integerIterator.next(), integerIterator.next(), integerIterator.next()],
+  "to equal",
+  [-2260084377780223, 5342043492581377, 8119347222413313]
+);
 ```
-
-### shrink(value)
-
-Returns a new generator that is shunken around the given value while still
-honoring the constraints of the original generator.
-
-```js
-integerIterator.shrink(1000);
-```
-
-This will shrink the iterator to produce values between `0` and `1000`.
-
-```js
-expect(integerIterator.take(5), "to equal", [183, 732, 780, 599, 597]);
-```
-
-If we shrink the iterator again with the smallest produces value from the last
-run. It will produce values been `0` and `183`.
-
-```js
-integerIterator.shrink(183);
-
-expect(integerIterator.take(5), "to equal", [28, 82, 28, 18, 10]);
-```
-
-The idea is that every time you find interesting input, you can try to search
-for a smaller input by shrinking the iterator.
 
 ### take(n)
 
 Produces `n` items with the generator and return them as an array:
 
 ```js
-expect(integer.values().take(3), "to equal", [
-  -2260084377780223,
-  5342043492581377,
-  8119347222413313
+expect(integerIterator.take(3), "to equal", [
+  -5702731889115135,
+  4179231256870913,
+  5038465087438849
 ]);
 ```
+
+### shrink()
+
+Returns a new generator that is shunken around the last generated value while
+still honoring the constraints of the original generator.
+
+```js
+const smallIntegersIterator = integer({ min: -10000, max: 10000 }).values();
+
+expect(smallIntegersIterator.next(), "to equal", -2509);
+
+smallIntegersIterator.shrink();
+```
+
+This will shrink the iterator to produce values between `0` and `-2509`.
+
+```js
+expect(smallIntegersIterator.take(5), "to equal", [
+  -510,
+  -123,
+  -2049,
+  -672,
+  -552
+]);
+```
+
+If we shrink the iterator again, it will produce values been `0` and `-552`.
+
+```js
+smallIntegersIterator.shrink();
+
+expect(smallIntegersIterator.take(5), "to equal", [
+  -221,
+  -222,
+  -466,
+  -306,
+  -466
+]);
+```
+
+The idea is that every time you find interesting input, you can try to search
+for a smaller input by shrinking the iterator.
+
+### expand()
+
+Expands the current generator around the last generated value while still
+honoring the constraints of the original generator.
+
+You can use this method when a generator produces an interesting input and you
+want to search around that value.
+
+```js
+const positiveIterator = natural({ min: 1, max: 1000 }).values();
+
+expect(positiveIterator.next(), "to equal", 375);
+
+positiveIterator.expand();
+
+expect(positiveIterator.take(10), "to equal", [
+  951,
+  375,
+  780,
+  394,
+  375,
+  306,
+  375,
+  375,
+  449,
+  375
+]);
+```
+
+As you can see the expanded iterator will produce values around `375` as that is
+our expansion value.

--- a/src/ArrayGenerator.js
+++ b/src/ArrayGenerator.js
@@ -33,7 +33,7 @@ class ArrayGenerator extends Generator {
     });
   }
 
-  expand(items) {
+  expand(items, context) {
     const { itemGenerator, min, max } = this.options;
 
     return new PicksetGenerator([itemGenerator, ...items], {

--- a/src/ArrayGenerator.js
+++ b/src/ArrayGenerator.js
@@ -18,14 +18,14 @@ class ArrayGenerator extends Generator {
     }
   }
 
-  shrink(items) {
+  shrink(items, context) {
     if (items.length === 0) {
       return new ConstantGenerator([]);
     }
 
     const itemGenerator = this.options.itemGenerator;
     if (itemGenerator.shrink) {
-      items = items.map(item => itemGenerator.shrink(item));
+      items = items.map(item => itemGenerator.shrink(item, context));
     }
 
     return new ArraySplicerGenerator(items, {

--- a/src/ArraySplicerGenerator.js
+++ b/src/ArraySplicerGenerator.js
@@ -15,8 +15,10 @@ class ArraySplicerGenerator extends Generator {
       return new ConstantGenerator([]);
     }
 
+    const lastValue = context.childContext(this).get("lastValue");
+
     const shrinkableData =
-      items.length < 10 && (this.lastValue || []).some(g => g && g.shrink);
+      items.length < 10 && (lastValue || []).some(g => g && g.shrink);
 
     let shrinkable = this.options.min < items.length || shrinkableData;
 
@@ -25,11 +27,11 @@ class ArraySplicerGenerator extends Generator {
     }
 
     if (shrinkableData) {
-      items = this.lastValue.map(
+      items = lastValue.map(
         (g, i) => (g && g.shrink ? g.shrink(items[i], context) : items[i])
       );
     } else {
-      items = this.lastValue;
+      items = lastValue;
     }
 
     return new ArraySplicerGenerator(items, {
@@ -51,10 +53,12 @@ class ArraySplicerGenerator extends Generator {
       max: Math.min(items.length - from, items.length - min)
     });
 
-    this.lastValue = items.slice();
-    this.lastValue.splice(from, length);
+    const value = items.slice();
+    value.splice(from, length);
 
-    return this.lastValue.map(
+    context.childContext(this).set("lastValue", value);
+
+    return value.map(
       item => (item && item.isGenerator ? item.generate(chance, context) : item)
     );
   }

--- a/src/ArraySplicerGenerator.js
+++ b/src/ArraySplicerGenerator.js
@@ -16,9 +16,7 @@ class ArraySplicerGenerator extends Generator {
     }
 
     const shrinkableData =
-      items.length < 10 &&
-      items === this.lastUnwrappedValue &&
-      (this.lastValue || []).some(g => g && g.shrink);
+      items.length < 10 && (this.lastValue || []).some(g => g && g.shrink);
 
     let shrinkable = this.options.min < items.length || shrinkableData;
 
@@ -56,11 +54,9 @@ class ArraySplicerGenerator extends Generator {
     this.lastValue = items.slice();
     this.lastValue.splice(from, length);
 
-    this.lastUnwrappedValue = this.lastValue.map(
+    return this.lastValue.map(
       item => (item && item.isGenerator ? item.generate(chance, context) : item)
     );
-
-    return this.lastUnwrappedValue;
   }
 }
 

--- a/src/ArraySplicerGenerator.js
+++ b/src/ArraySplicerGenerator.js
@@ -37,7 +37,7 @@ class ArraySplicerGenerator extends Generator {
     });
   }
 
-  expand(items) {
+  expand(items, context) {
     return new WeightedGenerator([
       [this, 1],
       [new ConstantGenerator(items), 1.5]

--- a/src/ArraySplicerGenerator.js
+++ b/src/ArraySplicerGenerator.js
@@ -10,7 +10,7 @@ class ArraySplicerGenerator extends Generator {
     });
   }
 
-  shrink(items) {
+  shrink(items, context) {
     if (items.length === 0) {
       return new ConstantGenerator([]);
     }
@@ -26,7 +26,7 @@ class ArraySplicerGenerator extends Generator {
 
     if (shrinkableData) {
       items = this.lastValue.map(
-        (g, i) => (g && g.shrink ? g.shrink(items[i]) : items[i])
+        (g, i) => (g && g.shrink ? g.shrink(items[i], context) : items[i])
       );
     } else {
       items = this.lastValue;

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,3 +1,5 @@
+const SimpleMap = require("./SimpleMap");
+
 class Context {
   get(key) {
     return this.data && this.data[key];
@@ -22,18 +24,18 @@ class Context {
 
   childContext(key) {
     if (!this.childContexts) {
-      this.childContexts = [];
+      this.childContexts = new SimpleMap();
     }
 
-    for (var i = 0; i < this.childContexts.length; i += 1) {
-      const entry = this.childContexts[i];
-      if (entry.key === key) {
-        return entry.context;
-      }
+    const childContext = this.childContexts.get(key);
+
+    if (childContext) {
+      return childContext;
     }
 
     const context = new Context();
-    this.childContexts.push({ key, context });
+    this.childContexts.set(key, context);
+
     return context;
   }
 }

--- a/src/FloatingGenerator.js
+++ b/src/FloatingGenerator.js
@@ -34,7 +34,7 @@ class FloatingGenerator extends Generator {
     }
   }
 
-  expand(value) {
+  expand(value, context) {
     return new WeightedGenerator([
       [new ConstantGenerator(value), 2],
       [

--- a/src/GeneratorIterator.js
+++ b/src/GeneratorIterator.js
@@ -22,13 +22,7 @@ class GeneratorIterator {
   }
 
   shrink() {
-    if (this.generated === uninitialized) {
-      throw new Error(
-        "You can't shrink an iterator that hasn't generated any values yet."
-      );
-    }
-
-    if (this.isShrinkable) {
+    if (this.generated !== uninitialized && this.isShrinkable) {
       this.generator = this.generator.shrink(this.generated, this.context);
       this.context = new Context();
       this.isShrinkable = Boolean(this.generator.shrink);
@@ -36,13 +30,7 @@ class GeneratorIterator {
   }
 
   expand() {
-    if (this.generated === uninitialized) {
-      throw new Error(
-        "You can't expand an iterator that hasn't generated any values yet."
-      );
-    }
-
-    if (this.isExpandable) {
+    if (this.generated !== uninitialized && this.isExpandable) {
       this.generator = this.generator.expand(this.generated, this.context);
       this.context = new Context();
       this.isExpandable = Boolean(this.generator.expand);

--- a/src/GeneratorIterator.js
+++ b/src/GeneratorIterator.js
@@ -29,7 +29,7 @@ class GeneratorIterator {
     }
 
     if (this.isShrinkable) {
-      this.generator = this.generator.shrink(this.generated);
+      this.generator = this.generator.shrink(this.generated, this.context);
       this.context = new Context();
       this.isShrinkable = Boolean(this.generator.shrink);
     }

--- a/src/GeneratorIterator.js
+++ b/src/GeneratorIterator.js
@@ -18,17 +18,17 @@ class GeneratorIterator {
     }
   }
 
-  shrink(value) {
+  shrink() {
     if (this.isShrinkable) {
-      this.generator = this.generator.shrink(value);
+      this.generator = this.generator.shrink(this.lastValue);
       this.context = new Context();
       this.isShrinkable = Boolean(this.generator.shrink);
     }
   }
 
-  expand(value) {
+  expand() {
     if (this.isExpandable) {
-      this.generator = this.generator.expand(value);
+      this.generator = this.generator.expand(this.lastValue);
       this.context = new Context();
       this.isExpandable = Boolean(this.generator.expand);
     }
@@ -49,7 +49,8 @@ class GeneratorIterator {
   }
 
   next() {
-    return this.generator.generate(this.chance, this.context);
+    this.lastValue = this.generator.generate(this.chance, this.context);
+    return this.lastValue;
   }
 }
 

--- a/src/GeneratorIterator.js
+++ b/src/GeneratorIterator.js
@@ -43,7 +43,7 @@ class GeneratorIterator {
     }
 
     if (this.isExpandable) {
-      this.generator = this.generator.expand(this.generated);
+      this.generator = this.generator.expand(this.generated, this.context);
       this.context = new Context();
       this.isExpandable = Boolean(this.generator.expand);
     }

--- a/src/IntegerGenerator.js
+++ b/src/IntegerGenerator.js
@@ -30,7 +30,7 @@ class IntegerGenerator extends Generator {
     }
   }
 
-  expand(value) {
+  expand(value, context) {
     return new WeightedGenerator([
       [new ConstantGenerator(value), 2],
       [

--- a/src/MagicFloatingGenerator.js
+++ b/src/MagicFloatingGenerator.js
@@ -7,7 +7,7 @@ class MagicFloatingGenerator extends Generator {
     super("magicFloating");
   }
 
-  expand(generated) {
+  expand(generated, context) {
     return new WeightedGenerator([[this, 1], [generated, 1.5]]);
   }
 

--- a/src/MagicIntegerGenerator.js
+++ b/src/MagicIntegerGenerator.js
@@ -7,7 +7,7 @@ class MagicIntegerGenerator extends Generator {
     super("magicInteger");
   }
 
-  expand(generated) {
+  expand(generated, context) {
     return new WeightedGenerator([[this, 1], [generated, 1.5]]);
   }
 

--- a/src/MagicStringGenerator.js
+++ b/src/MagicStringGenerator.js
@@ -7,7 +7,7 @@ class MagicStringGenerator extends Generator {
     super("magicString");
   }
 
-  expand(generated) {
+  expand(generated, context) {
     return new WeightedGenerator([[this, 1], [generated, 1.5]]);
   }
 

--- a/src/MappingGenerator.js
+++ b/src/MappingGenerator.js
@@ -8,9 +8,9 @@ class MappingGenerator extends Generator {
     this.parentGenerator = generator;
 
     if (generator.shrink) {
-      this.shrink = value => {
+      this.shrink = (value, context) => {
         if (value === this.lastMappedValue) {
-          return generator.shrink(this.lastValue).map(mapper);
+          return generator.shrink(this.lastValue, context).map(mapper);
         } else {
           return this;
         }

--- a/src/MappingGenerator.js
+++ b/src/MappingGenerator.js
@@ -9,37 +9,29 @@ class MappingGenerator extends Generator {
 
     if (generator.shrink) {
       this.shrink = (value, context) => {
-        if (value === this.lastMappedValue) {
-          return generator.shrink(this.lastValue, context).map(mapper);
-        } else {
-          return this;
-        }
+        const lastValue = context.childContext(this).get("lastValue");
+
+        return generator.shrink(lastValue, context).map(mapper);
       };
     }
 
     if (generator.expand) {
       this.expand = (value, context) => {
-        if (value === this.lastMappedValue) {
-          return generator.expand(this.lastValue, context).map(mapper);
-        } else {
-          return this;
-        }
+        const lastValue = context.childContext(this).get("lastValue");
+
+        return generator.expand(lastValue, context).map(mapper);
       };
     }
   }
 
   generate(chance, context) {
-    this.lastValue = this.parentGenerator.generate(chance, context);
+    const value = this.parentGenerator.generate(chance, context);
+
+    context.childContext(this).set("lastValue", value);
 
     const { mapper } = this.options;
 
-    this.lastMappedValue = unwrap(
-      mapper(this.lastValue, chance),
-      chance,
-      context
-    );
-
-    return this.lastMappedValue;
+    return unwrap(mapper(value, chance), chance, context);
   }
 }
 

--- a/src/MappingGenerator.js
+++ b/src/MappingGenerator.js
@@ -18,9 +18,9 @@ class MappingGenerator extends Generator {
     }
 
     if (generator.expand) {
-      this.expand = value => {
+      this.expand = (value, context) => {
         if (value === this.lastMappedValue) {
-          return generator.expand(this.lastValue).map(mapper);
+          return generator.expand(this.lastValue, context).map(mapper);
         } else {
           return this;
         }

--- a/src/MappingGenerator.spec.js
+++ b/src/MappingGenerator.spec.js
@@ -43,9 +43,12 @@ describe("MappingGenerator", () => {
 
   describe("expand", () => {
     it("expands the parent generator and maps it again", () => {
-      const value = mapGenerator.first();
+      const iterator = mapGenerator.values();
 
-      expect(mapGenerator.expand(value), "to yield items", [
+      iterator.next();
+      iterator.expand();
+
+      expect(iterator, "to yield items", [
         "E)1(N25SSLGLTEH#YSK0",
         "A(N25SSLGLHEH#YJK09",
         "(%25SSLGLHEH)YSK0U",

--- a/src/NumberGenerator.js
+++ b/src/NumberGenerator.js
@@ -67,8 +67,8 @@ class NumberGenerator extends Generator {
     return this.composedGenerator.shrink(number, context);
   }
 
-  expand(number) {
-    return this.composedGenerator.expand(number);
+  expand(number, context) {
+    return this.composedGenerator.expand(number, context);
   }
 
   generate(chance, context) {

--- a/src/NumberGenerator.js
+++ b/src/NumberGenerator.js
@@ -63,8 +63,8 @@ class NumberGenerator extends Generator {
     this.composedGenerator = new WeightedGenerator(generators);
   }
 
-  shrink(number) {
-    return this.composedGenerator.shrink(number);
+  shrink(number, context) {
+    return this.composedGenerator.shrink(number, context);
   }
 
   expand(number) {

--- a/src/PickoneGenerator.js
+++ b/src/PickoneGenerator.js
@@ -22,12 +22,12 @@ class PickoneGenerator extends Generator {
     }
   }
 
-  expand(item) {
+  expand(item, context) {
     const expandableItem = this.lastValue && this.lastValue.expand;
 
     return new WeightedGenerator([
       [this, 10],
-      [expandableItem ? this.lastValue.expand(item) : item, 15]
+      [expandableItem ? this.lastValue.expand(item, context) : item, 15]
     ]);
   }
 

--- a/src/PickoneGenerator.js
+++ b/src/PickoneGenerator.js
@@ -14,9 +14,9 @@ class PickoneGenerator extends Generator {
     }
   }
 
-  shrink(item) {
+  shrink(item, context) {
     if (this.lastValue && this.lastValue.shrink) {
-      return this.lastValue.shrink(item);
+      return this.lastValue.shrink(item, context);
     } else {
       return new ConstantGenerator(item);
     }

--- a/src/PickoneGenerator.js
+++ b/src/PickoneGenerator.js
@@ -15,7 +15,7 @@ class PickoneGenerator extends Generator {
   }
 
   shrink(item) {
-    if (this.lastUnwrappedValue === item && this.lastValue.shrink) {
+    if (this.lastValue && this.lastValue.shrink) {
       return this.lastValue.shrink(item);
     } else {
       return new ConstantGenerator(item);
@@ -23,8 +23,7 @@ class PickoneGenerator extends Generator {
   }
 
   expand(item) {
-    const expandableItem =
-      this.lastUnwrappedValue === item && this.lastValue.expand;
+    const expandableItem = this.lastValue && this.lastValue.expand;
 
     return new WeightedGenerator([
       [this, 10],
@@ -38,9 +37,7 @@ class PickoneGenerator extends Generator {
     const index = chance.natural({ max: items.length - 1 });
     this.lastValue = items[index];
 
-    this.lastUnwrappedValue = unwrap(this.lastValue, chance, context);
-
-    return this.lastUnwrappedValue;
+    return unwrap(this.lastValue, chance, context);
   }
 }
 

--- a/src/PickoneGenerator.js
+++ b/src/PickoneGenerator.js
@@ -15,19 +15,22 @@ class PickoneGenerator extends Generator {
   }
 
   shrink(item, context) {
-    if (this.lastValue && this.lastValue.shrink) {
-      return this.lastValue.shrink(item, context);
+    const lastValue = context.childContext(this).get("lastValue");
+
+    if (lastValue && lastValue.shrink) {
+      return lastValue.shrink(item, context);
     } else {
       return new ConstantGenerator(item);
     }
   }
 
   expand(item, context) {
-    const expandableItem = this.lastValue && this.lastValue.expand;
+    const lastValue = context.childContext(this).get("lastValue");
+    const expandableItem = lastValue && lastValue.expand;
 
     return new WeightedGenerator([
       [this, 10],
-      [expandableItem ? this.lastValue.expand(item, context) : item, 15]
+      [expandableItem ? lastValue.expand(item, context) : item, 15]
     ]);
   }
 
@@ -35,9 +38,11 @@ class PickoneGenerator extends Generator {
     const { items } = this.options;
 
     const index = chance.natural({ max: items.length - 1 });
-    this.lastValue = items[index];
+    const value = items[index];
 
-    return unwrap(this.lastValue, chance, context);
+    context.childContext(this).set("lastValue", value);
+
+    return unwrap(value, chance, context);
   }
 }
 

--- a/src/PickoneGenerator.spec.js
+++ b/src/PickoneGenerator.spec.js
@@ -33,7 +33,10 @@ describe("PickoneGenerator", () => {
 
   describe("shrink", () => {
     it("returns a constant generator with the given value", () => {
-      expect(generator.shrink(5), "to satisfy", { options: { value: 5 } }).and(
+      const iterator = generator.values();
+      iterator.next();
+      iterator.shrink();
+      expect(iterator.generator, "to satisfy", { options: { value: 3 } }).and(
         "to be a",
         ConstantGenerator
       );
@@ -42,7 +45,10 @@ describe("PickoneGenerator", () => {
 
   describe("expand", () => {
     it("returns a new generator that is more likely to pick the given item", () => {
-      expect(generator.expand(5), "to yield items", [7, 5, 7, 5, 5, 5, 4, 0]);
+      const iterator = generator.values();
+      iterator.next();
+      iterator.expand();
+      expect(iterator, "to yield items", [3, 3, 7, 3, 3, 3, 4, 0]);
     });
   });
 
@@ -67,8 +73,11 @@ describe("PickoneGenerator", () => {
 
     describe("shrink", () => {
       it("returns the shrunken generator that it was given", () => {
-        const value = generator.first();
-        expect(generator.shrink(value), "to satisfy", {
+        const iterator = generator.values();
+        iterator.next();
+        iterator.shrink();
+
+        expect(iterator.generator, "to satisfy", {
           generatorName: "integer",
           options: { min: 0, max: 80 }
         });
@@ -77,11 +86,12 @@ describe("PickoneGenerator", () => {
 
     describe("expand", () => {
       it("returns a new generator that is more likely to pick expansions around the given item", () => {
-        const value = generator.take(2)[1];
+        const iterator = generator.values();
+        iterator.next();
+        iterator.next();
+        iterator.expand();
 
-        expect(value, "to equal", "5SSlG");
-
-        expect(generator.expand(value), "to yield items", [
+        expect(iterator, "to yield items", [
           5,
           "Sk5WSlG19",
           "CM[RId@SYmHea(*)P7C",

--- a/src/PicksetGenerator.js
+++ b/src/PicksetGenerator.js
@@ -42,7 +42,7 @@ class PicksetGenerator extends Generator {
     });
   }
 
-  expand(data) {
+  expand(data, context) {
     return this.map((items, chance) => {
       const margin = Math.max(
         Math.min(

--- a/src/PicksetGenerator.js
+++ b/src/PicksetGenerator.js
@@ -14,7 +14,7 @@ class PicksetGenerator extends Generator {
     }
   }
 
-  shrink(items) {
+  shrink(items, context) {
     if (items.length === 0) {
       return new ConstantGenerator([]);
     }
@@ -30,7 +30,7 @@ class PicksetGenerator extends Generator {
 
     if (shrinkableData) {
       items = this.lastValue.map(
-        (g, i) => (g && g.shrink ? g.shrink(items[i]) : items[i])
+        (g, i) => (g && g.shrink ? g.shrink(items[i], context) : items[i])
       );
     } else {
       items = this.lastValue;

--- a/src/PicksetGenerator.js
+++ b/src/PicksetGenerator.js
@@ -19,8 +19,10 @@ class PicksetGenerator extends Generator {
       return new ConstantGenerator([]);
     }
 
+    const lastValue = context.childContext(this).get("lastValue");
+
     const shrinkableData =
-      items.length < 10 && (this.lastValue || []).some(g => g && g.shrink);
+      items.length < 10 && (lastValue || []).some(g => g && g.shrink);
 
     let shrinkable = items.length < this.options.max || shrinkableData;
 
@@ -29,11 +31,11 @@ class PicksetGenerator extends Generator {
     }
 
     if (shrinkableData) {
-      items = this.lastValue.map(
+      items = lastValue.map(
         (g, i) => (g && g.shrink ? g.shrink(items[i], context) : items[i])
       );
     } else {
-      items = this.lastValue;
+      items = lastValue;
     }
 
     return new PicksetGenerator(items, {
@@ -86,9 +88,11 @@ class PicksetGenerator extends Generator {
   generate(chance, context) {
     const { items, min, max } = this.options;
 
-    this.lastValue = chance.pickset(items, chance.natural({ min, max }));
+    const value = chance.pickset(items, chance.natural({ min, max }));
 
-    return this.lastValue.map(
+    context.childContext(this).set("lastValue", value);
+
+    return value.map(
       item => (item && item.isGenerator ? item.generate(chance, context) : item)
     );
   }

--- a/src/PicksetGenerator.js
+++ b/src/PicksetGenerator.js
@@ -20,9 +20,7 @@ class PicksetGenerator extends Generator {
     }
 
     const shrinkableData =
-      items.length < 10 &&
-      items === this.lastUnwrappedValue &&
-      (this.lastValue || []).some(g => g && g.shrink);
+      items.length < 10 && (this.lastValue || []).some(g => g && g.shrink);
 
     let shrinkable = items.length < this.options.max || shrinkableData;
 
@@ -90,11 +88,9 @@ class PicksetGenerator extends Generator {
 
     this.lastValue = chance.pickset(items, chance.natural({ min, max }));
 
-    this.lastUnwrappedValue = this.lastValue.map(
+    return this.lastValue.map(
       item => (item && item.isGenerator ? item.generate(chance, context) : item)
     );
-
-    return this.lastUnwrappedValue;
   }
 }
 

--- a/src/PrimitiveGenerator.js
+++ b/src/PrimitiveGenerator.js
@@ -21,8 +21,8 @@ class PrimitiveGenerator extends Generator {
     return this.composedGenerator.shrink(value, context);
   }
 
-  expand(value) {
-    return this.composedGenerator.expand(value);
+  expand(value, context) {
+    return this.composedGenerator.expand(value, context);
   }
 
   generate(chance, context) {

--- a/src/PrimitiveGenerator.js
+++ b/src/PrimitiveGenerator.js
@@ -17,8 +17,8 @@ class PrimitiveGenerator extends Generator {
     ]);
   }
 
-  shrink(value) {
-    return this.composedGenerator.shrink(value);
+  shrink(value, context) {
+    return this.composedGenerator.shrink(value, context);
   }
 
   expand(value) {

--- a/src/PrimitiveGenerator.spec.js
+++ b/src/PrimitiveGenerator.spec.js
@@ -29,20 +29,21 @@ describe("PrimitiveGenerator", () => {
 
   describe("shrink", () => {
     it("shrinks the primitive value", () => {
-      const value = generator.first();
+      const iterator = generator.values();
 
-      expect(value, "to equal", 9015);
-      expect(generator.shrink(value), "to shrink towards", 0);
+      expect(iterator.next(), "to equal", 9015);
+      expect(iterator, "to shrink towards", 0);
     });
   });
 
   describe("expand", () => {
     it("expands the primitive value", () => {
-      const value = generator.first();
+      const iterator = generator.values();
 
-      expect(value, "to equal", 9015);
+      expect(iterator.next(), "to equal", 9015);
 
-      expect(generator.expand(value), "to yield items", [
+      iterator.expand();
+      expect(iterator, "to yield items", [
         56,
         -6880,
         "Ej wocu ofaufjom be mabuj do lisib valbuunu bave dolbaw gokim sab.",

--- a/src/SequenceGenerator.js
+++ b/src/SequenceGenerator.js
@@ -36,7 +36,7 @@ class SequenceGenerator extends Generator {
     });
   }
 
-  expand(items) {
+  expand(items, context) {
     const { producer, max, initialValue } = this.options;
 
     if (items.length < max) {

--- a/src/ShapeGenerator.js
+++ b/src/ShapeGenerator.js
@@ -19,16 +19,16 @@ const containsGeneratorsMatching = (shape, predicate) => {
   }
 };
 
-const shrink = (shape, generated) => {
+const shrink = (shape, generated, context) => {
   if (!shape) {
     return shape;
   } else if (Array.isArray(shape)) {
-    return shape.map((item, i) => shrink(item, generated[i]));
+    return shape.map((item, i) => shrink(item, generated[i]), context);
   } else if (shape.isGenerator) {
-    return shape.shrink ? shape.shrink(generated) : shape;
+    return shape.shrink ? shape.shrink(generated, context) : shape;
   } else if (typeof shape === "object") {
     return Object.keys(shape).reduce((result, key) => {
-      result[key] = shrink(shape[key], generated[key]);
+      result[key] = shrink(shape[key], generated[key], context);
       return result;
     }, {});
   } else {
@@ -58,13 +58,13 @@ class ShapeGenerator extends Generator {
     super("shape", shape);
   }
 
-  shrink(generated) {
+  shrink(generated, context) {
     const isShrinkable = containsGeneratorsMatching(this.options, generator =>
       Boolean(generator.shrink)
     );
 
     if (isShrinkable) {
-      return new ShapeGenerator(shrink(this.options, generated));
+      return new ShapeGenerator(shrink(this.options, generated, context));
     } else {
       return new ConstantGenerator(generated);
     }

--- a/src/ShapeGenerator.js
+++ b/src/ShapeGenerator.js
@@ -36,16 +36,16 @@ const shrink = (shape, generated, context) => {
   }
 };
 
-const expand = (shape, generated) => {
+const expand = (shape, generated, context) => {
   if (!shape) {
     return shape;
   } else if (Array.isArray(shape)) {
-    return shape.map((item, i) => expand(item, generated[i]));
+    return shape.map((item, i) => expand(item, generated[i], context));
   } else if (shape.isGenerator) {
-    return shape.expand ? shape.expand(generated) : shape;
+    return shape.expand ? shape.expand(generated, context) : shape;
   } else if (typeof shape === "object") {
     return Object.keys(shape).reduce((result, key) => {
-      result[key] = expand(shape[key], generated[key]);
+      result[key] = expand(shape[key], generated[key], context);
       return result;
     }, {});
   } else {
@@ -70,14 +70,14 @@ class ShapeGenerator extends Generator {
     }
   }
 
-  expand(generated) {
+  expand(generated, context) {
     const isExpandable = containsGeneratorsMatching(this.options, generator =>
       Boolean(generator.expand)
     );
 
     if (isExpandable) {
       return new WeightedGenerator([
-        [new ShapeGenerator(expand(this.options, generated)), 1],
+        [new ShapeGenerator(expand(this.options, generated, context)), 1],
         [new ConstantGenerator(generated), 1.5]
       ]);
     } else {

--- a/src/ShuffleGenerator.js
+++ b/src/ShuffleGenerator.js
@@ -27,7 +27,7 @@ class ShuffleGenerator extends Generator {
     }
   }
 
-  expand(items) {
+  expand(items, context) {
     return new WeightedGenerator([
       [this, 1],
       [new ConstantGenerator(items), 1.5]

--- a/src/ShuffleGenerator.js
+++ b/src/ShuffleGenerator.js
@@ -14,9 +14,7 @@ class ShuffleGenerator extends Generator {
   }
 
   shrink(items) {
-    const shrinkable =
-      items === this.lastUnwrappedValue &&
-      (this.lastValue || []).some(g => g && g.shrink);
+    const shrinkable = (this.lastValue || []).some(g => g && g.shrink);
 
     if (shrinkable) {
       return new ShuffleGenerator(
@@ -41,11 +39,9 @@ class ShuffleGenerator extends Generator {
 
     this.lastValue = chance.shuffle(items);
 
-    this.lastUnwrappedValue = this.lastValue.map(
+    return this.lastValue.map(
       item => (item && item.isGenerator ? item.generate(chance, context) : item)
     );
-
-    return this.lastUnwrappedValue;
   }
 }
 

--- a/src/ShuffleGenerator.js
+++ b/src/ShuffleGenerator.js
@@ -14,11 +14,12 @@ class ShuffleGenerator extends Generator {
   }
 
   shrink(items, context) {
-    const shrinkable = (this.lastValue || []).some(g => g && g.shrink);
+    const lastValue = context.childContext(this).get("lastValue");
+    const shrinkable = (lastValue || []).some(g => g && g.shrink);
 
     if (shrinkable) {
       return new ShuffleGenerator(
-        this.lastValue.map(
+        lastValue.map(
           (g, i) => (g && g.shrink ? g.shrink(items[i], context) : items[i])
         )
       );
@@ -37,9 +38,11 @@ class ShuffleGenerator extends Generator {
   generate(chance, context) {
     const { items } = this.options;
 
-    this.lastValue = chance.shuffle(items);
+    const value = chance.shuffle(items);
 
-    return this.lastValue.map(
+    context.childContext(this).set("lastValue", value);
+
+    return value.map(
       item => (item && item.isGenerator ? item.generate(chance, context) : item)
     );
   }

--- a/src/ShuffleGenerator.js
+++ b/src/ShuffleGenerator.js
@@ -13,13 +13,13 @@ class ShuffleGenerator extends Generator {
     }
   }
 
-  shrink(items) {
+  shrink(items, context) {
     const shrinkable = (this.lastValue || []).some(g => g && g.shrink);
 
     if (shrinkable) {
       return new ShuffleGenerator(
         this.lastValue.map(
-          (g, i) => (g && g.shrink ? g.shrink(items[i]) : items[i])
+          (g, i) => (g && g.shrink ? g.shrink(items[i], context) : items[i])
         )
       );
     } else {

--- a/src/SimpleMap.js
+++ b/src/SimpleMap.js
@@ -1,0 +1,26 @@
+class SimpleMap {
+  constructor() {
+    this.keys = [];
+    this.values = [];
+  }
+
+  set(key, value) {
+    const index = this.keys.indexOf(key);
+
+    if (index === -1) {
+      this.keys.push(key);
+      this.values.push(value);
+    } else {
+      this.keys[index] = key;
+      this.values[index] = value;
+    }
+  }
+
+  get(key) {
+    const index = this.keys.indexOf(key);
+
+    return this.values[index];
+  }
+}
+
+module.exports = typeof Map === "function" ? Map : SimpleMap;

--- a/src/StringGenerator.js
+++ b/src/StringGenerator.js
@@ -20,7 +20,7 @@ class StringGenerator extends Generator {
     return new StringSplicerGenerator(text, { min: this.options.min });
   }
 
-  expand(data) {
+  expand(data, context) {
     return this.map((text, chance) => {
       const margin = Math.max(
         Math.min(

--- a/src/StringSplicerGenerator.js
+++ b/src/StringSplicerGenerator.js
@@ -26,7 +26,7 @@ class StringSplicerGenerator extends Generator {
     return new StringSplicerGenerator(text, { min });
   }
 
-  expand(text) {
+  expand(text, context) {
     return new WeightedGenerator([
       [this, 1],
       [new ConstantGenerator(text), 1.5]

--- a/src/TextGenerator.js
+++ b/src/TextGenerator.js
@@ -33,8 +33,8 @@ class TextGenerator extends Generator {
     return new StringGenerator({ max: text.length }).shrink(text, context);
   }
 
-  expand(text) {
-    return new StringGenerator({ max: text.length + 10 }).expand(text);
+  expand(text, context) {
+    return new StringGenerator({ max: text.length + 10 }).expand(text, context);
   }
 
   generate(chance, context) {

--- a/src/TextGenerator.js
+++ b/src/TextGenerator.js
@@ -29,8 +29,8 @@ class TextGenerator extends Generator {
     ]);
   }
 
-  shrink(text) {
-    return new StringGenerator({ max: text.length }).shrink(text);
+  shrink(text, context) {
+    return new StringGenerator({ max: text.length }).shrink(text, context);
   }
 
   expand(text) {

--- a/src/TreeGenerator.js
+++ b/src/TreeGenerator.js
@@ -77,8 +77,8 @@ class TreeGenerator extends Generator {
     return this.composedGenerator.expand(value);
   }
 
-  shrink(value) {
-    return this.composedGenerator.shrink(value);
+  shrink(value, context) {
+    return this.composedGenerator.shrink(value, context);
   }
 
   generate(chance, context) {

--- a/src/TreeGenerator.js
+++ b/src/TreeGenerator.js
@@ -73,8 +73,8 @@ class TreeGenerator extends Generator {
     }).map(arrayToTree);
   }
 
-  expand(value) {
-    return this.composedGenerator.expand(value);
+  expand(value, context) {
+    return this.composedGenerator.expand(value, context);
   }
 
   shrink(value, context) {

--- a/src/TreeGenerator.spec.js
+++ b/src/TreeGenerator.spec.js
@@ -77,9 +77,9 @@ describe("TreeGenerator", () => {
 
     describe("expand", () => {
       it("produces a generator that will generate trees similar to the given value", () => {
-        const value = generator.first();
+        const iterator = generator.values();
 
-        expect(value, "to equal", [
+        expect(iterator.next(), "to equal", [
           80,
           [96, [18, 73], 78, 60],
           [[60, 15], 45],
@@ -87,7 +87,9 @@ describe("TreeGenerator", () => {
           10
         ]);
 
-        expect(generator.expand(value).take(3), "to equal", [
+        iterator.expand();
+
+        expect(iterator, "to yield items", [
           [45, [[15, 96], 43], [80, 60, 60, 18, 78], 73, 10, 15],
           [60, 96, [18, 73], [10, [15, 15], 45], 45, 80, 78, 60],
           [15, [[96, [73, 60], 26], 45], 15]
@@ -125,10 +127,13 @@ describe("TreeGenerator", () => {
 
     describe("expand", () => {
       it("honor the constaints", () => {
-        const value = generator.first();
+        const iterator = generator.values();
+
+        iterator.next();
+        iterator.expand();
 
         expect(
-          generator.expand(value),
+          iterator,
           "to yield items satisfying",
           "to have size satisfying",
           "to be within",
@@ -163,10 +168,13 @@ describe("TreeGenerator", () => {
 
     describe("expand", () => {
       it("honor the constaints", () => {
-        const value = generator.first();
+        const iterator = generator.values();
+
+        iterator.next();
+        iterator.expand();
 
         expect(
-          generator.expand(value),
+          iterator,
           "to yield items satisfying",
           "to have size satisfying",
           "to be within",

--- a/src/UniqueGenerator.js
+++ b/src/UniqueGenerator.js
@@ -29,7 +29,7 @@ class UniqueGenerator extends Generator {
     });
   }
 
-  expand(items) {
+  expand(items, context) {
     return new WeightedGenerator([
       [this, 1],
       [new ConstantGenerator(items), 1.5]

--- a/src/WeightedGenerator.js
+++ b/src/WeightedGenerator.js
@@ -14,7 +14,7 @@ class WeightedGenerator extends Generator {
   }
 
   shrink(item) {
-    if (this.lastUnwrappedValue === item && this.lastValue.shrink) {
+    if (this.lastValue && this.lastValue.shrink) {
       return this.lastValue.shrink(item);
     } else {
       return new ConstantGenerator(item);
@@ -22,13 +22,7 @@ class WeightedGenerator extends Generator {
   }
 
   expand(item) {
-    const isGeneratorItem = this.lastValue && this.lastValue.isGenerator;
-
-    const expandableItem =
-      this.lastUnwrappedValue === item &&
-      isGeneratorItem &&
-      this.lastValue.expand;
-
+    const expandableItem = this.lastValue && this.lastValue.expand;
     const expandedItem = expandableItem ? this.lastValue.expand(item) : item;
 
     const maxWeight = this.options.reduce(
@@ -58,9 +52,8 @@ class WeightedGenerator extends Generator {
     });
 
     this.lastValue = chance.weighted(items, weights);
-    this.lastUnwrappedValue = unwrap(this.lastValue, chance, context);
 
-    return this.lastUnwrappedValue;
+    return unwrap(this.lastValue, chance, context);
   }
 }
 

--- a/src/WeightedGenerator.js
+++ b/src/WeightedGenerator.js
@@ -14,17 +14,21 @@ class WeightedGenerator extends Generator {
   }
 
   shrink(item, context) {
-    if (this.lastValue && this.lastValue.shrink) {
-      return this.lastValue.shrink(item, context);
+    const lastValue = context.childContext(this).get("lastValue");
+
+    if (lastValue && lastValue.shrink) {
+      return lastValue.shrink(item, context);
     } else {
       return new ConstantGenerator(item);
     }
   }
 
   expand(item, context) {
-    const expandableItem = this.lastValue && this.lastValue.expand;
+    const lastValue = context.childContext(this).get("lastValue");
+
+    const expandableItem = lastValue && lastValue.expand;
     const expandedItem = expandableItem
-      ? this.lastValue.expand(item, context)
+      ? lastValue.expand(item, context)
       : item;
 
     const maxWeight = this.options.reduce(
@@ -35,7 +39,7 @@ class WeightedGenerator extends Generator {
     const filteredOptions = expandableItem
       ? this.options
       : this.options.filter(
-          ([optionItem]) => optionItem !== item && optionItem !== this.lastValue
+          ([optionItem]) => optionItem !== item && optionItem !== lastValue
         );
 
     return new WeightedGenerator([
@@ -53,9 +57,11 @@ class WeightedGenerator extends Generator {
       weights.push(weight);
     });
 
-    this.lastValue = chance.weighted(items, weights);
+    const value = chance.weighted(items, weights);
 
-    return unwrap(this.lastValue, chance, context);
+    context.childContext(this).set("lastValue", value);
+
+    return unwrap(value, chance, context);
   }
 }
 

--- a/src/WeightedGenerator.js
+++ b/src/WeightedGenerator.js
@@ -13,9 +13,9 @@ class WeightedGenerator extends Generator {
     }
   }
 
-  shrink(item) {
+  shrink(item, context) {
     if (this.lastValue && this.lastValue.shrink) {
-      return this.lastValue.shrink(item);
+      return this.lastValue.shrink(item, context);
     } else {
       return new ConstantGenerator(item);
     }

--- a/src/WeightedGenerator.js
+++ b/src/WeightedGenerator.js
@@ -21,9 +21,11 @@ class WeightedGenerator extends Generator {
     }
   }
 
-  expand(item) {
+  expand(item, context) {
     const expandableItem = this.lastValue && this.lastValue.expand;
-    const expandedItem = expandableItem ? this.lastValue.expand(item) : item;
+    const expandedItem = expandableItem
+      ? this.lastValue.expand(item, context)
+      : item;
 
     const maxWeight = this.options.reduce(
       (result, [item, weight]) => Math.max(result, weight),

--- a/src/WeightedGenerator.spec.js
+++ b/src/WeightedGenerator.spec.js
@@ -44,16 +44,26 @@ describe("WeightedGenerator", () => {
 
   describe("shrink", () => {
     it("returns a constant generator with the given value", () => {
-      expect(generator.shrink("four"), "to satisfy", {
-        options: { value: "four" }
+      const iterator = generator.values();
+
+      iterator.next();
+      iterator.shrink();
+
+      expect(iterator.generator, "to satisfy", {
+        options: { value: "one" }
       }).and("to be a", ConstantGenerator);
     });
   });
 
   describe("expand", () => {
     it("return new weighted generator where the found item is more likely to get picked again", () => {
-      expect(generator.expand("four"), "to satisfy", {
-        options: [["one", 50], ["two", 10], ["three", 30], ["four", 50 * 1.5]]
+      const iterator = generator.values();
+
+      iterator.next();
+      iterator.expand();
+
+      expect(iterator.generator, "to satisfy", {
+        options: [["two", 10], ["three", 30], ["four", 10], ["one", 50 * 1.5]]
       }).and("to be a", WeightedGenerator);
     });
   });
@@ -79,8 +89,12 @@ describe("WeightedGenerator", () => {
 
     describe("shrink", () => {
       it("returns the shrunken generator that it was given", () => {
-        const value = generator.first();
-        expect(generator.shrink(value), "to satisfy", {
+        const iterator = generator.values();
+
+        iterator.next();
+        iterator.shrink();
+
+        expect(iterator.generator, "to satisfy", {
           generatorName: "stringSplicer",
           options: { text: "n25SSlGlheH#ySk0Wbe)19*pa", min: 5 }
         });
@@ -89,9 +103,12 @@ describe("WeightedGenerator", () => {
 
     describe("expand", () => {
       it("returns a weighted generator where the found item is expanded and the weight is increased", () => {
-        const value = generator.first();
+        const iterator = generator.values();
 
-        expect(generator.expand(value), "to yield items", [
+        iterator.next();
+        iterator.expand();
+
+        expect(iterator, "to yield items", [
           "TwTMaFbvMTDkdv[BrHg6ToCM[RId@S",
           "n25SSlGlheH#ySk0Wbe)19*pa",
           "n25SSlG&heH#ySk0Wbe)19*pa",

--- a/test/expect.js
+++ b/test/expect.js
@@ -69,8 +69,8 @@ module.exports = require("unexpected")
       let count = 0;
       let iterator = subject.values();
       while (iterator.isShrinkable && count < 100) {
-        const value = iterator.next();
-        iterator.shrink(value);
+        iterator.next();
+        iterator.shrink();
         count++;
       }
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -17,6 +17,23 @@ module.exports = require("unexpected")
   })
   .addType({
     base: "object",
+    name: "GeneratorIterator",
+    identify: v => v && v.isGeneratorIterator,
+    inspect: (v, depth, output, inspect) => {
+      output.jsFunctionName(v.generator.generatorName);
+
+      if (typeof v.options !== "undefined") {
+        output
+          .text("(")
+          .appendInspected(v.generator.options)
+          .text(").")
+          .jsFunctionName("values")
+          .text("()");
+      }
+    }
+  })
+  .addType({
+    base: "object",
     name: "MappingGenerator",
     identify: v => v && v.isMappedGenerator,
     inspect: (v, depth, output, inspect) => {
@@ -35,14 +52,14 @@ module.exports = require("unexpected")
     }
   )
   .addAssertion(
-    "<Generator> to yield items <array>",
+    "<Generator|GeneratorIterator> to yield items <array>",
     (expect, subject, values) => {
       expect.errorMode = "nested";
       expect(subject.take(values.length), "to equal", values);
     }
   )
   .addAssertion(
-    "<Generator> to yield items satisfying <any>",
+    "<Generator|GeneratorIterator> to yield items satisfying <any>",
     (expect, subject, value) => {
       expect.errorMode = "nested";
       expect(
@@ -53,7 +70,7 @@ module.exports = require("unexpected")
     }
   )
   .addAssertion(
-    "<Generator> to yield items satisfying <assertion>",
+    "<Generator|GeneratorIterator> to yield items satisfying <assertion>",
     (expect, subject) => {
       expect.errorMode = "nested";
       subject.take(10).forEach(item => {
@@ -62,15 +79,14 @@ module.exports = require("unexpected")
     }
   )
   .addAssertion(
-    "<Generator> to shrink towards <any>",
+    "<GeneratorIterator> to shrink towards <any>",
     (expect, subject, value) => {
       expect.errorMode = "nested";
 
       let count = 0;
-      let iterator = subject.values();
-      while (iterator.isShrinkable && count < 100) {
-        iterator.next();
-        iterator.shrink();
+      while (subject.isShrinkable && count < 100) {
+        subject.next();
+        subject.shrink();
         count++;
       }
 
@@ -78,7 +94,15 @@ module.exports = require("unexpected")
         expect.fail("Could not shrink in 100 iterations");
       }
 
-      expect(iterator.next(), "to equal", value);
+      expect(subject.next(), "to equal", value);
+    }
+  )
+  .addAssertion(
+    "<Generator> to shrink towards <any>",
+    (expect, subject, value) => {
+      expect.errorMode = "bubble";
+
+      expect(subject.values(), "to shrink towards", value);
     }
   )
   .addAssertion("<number> [not] to be an integer", (expect, subject) => {


### PR DESCRIPTION
It has been bothering me, that you have to make sure to pass the generated values to shrink and expand manually and in addition to that I was storing information on the generators which should be stateless as they are just a description of how to generate values. I haven't known how to solve this problem until now. But I think this is a good solution and given that we are just removing an argument, I think this should be backwards compatible with regards to the documented API.

Tested against unexpected-check's test suite.